### PR TITLE
use KB instead of kb.

### DIFF
--- a/02d_matmul_cdna3/README.md
+++ b/02d_matmul_cdna3/README.md
@@ -32,12 +32,12 @@ rocprof-compute analyze -p workloads/mm_v1a/MI300
 ```
 
 Worklog
-- v1a: Basic matmul structure. gmem->smem via registers. No pipelining. Understand mfma layout.
+- v1a: Basic matmul structure. gmem->smem via registers. No pipelining. Understand mfma layout.  
 - Tried `rocprof-compute`, but I didn't know where to look for bottlenecks, like Nsight Compute's warp stall analysis does.
 - v1b: Reduce smem bank conflicts with padded smem or swizzling.
 - Most errors don't segfault / error immediately e.g. reading out of bounds for smem. This makes it hard to identify bugs.
 - v2: smem swizzling. During smem->gmem, we are loading a 16x16 BF16 tile, where each thread loads 4 BF16 elements. MI300X has 32 4-byte banks just like NVIDIA GPUs do, but it's not clear how this 16x16 BF16 load will be divided into 4 memory transactions. I was guessing it will be a 16x4 tile, corresponding to thread 0-15 and so on, but it turns out swizzling for 8x8 tile still works! Looks like MI300X is pretty smart on how to break down a large smem request into serial transactions.
-- v3a: double buffering via registers. Since MI300X has limited smem (64kb vs 164kb on Ampere), but plenty of rmem (512kb vs 256kb on all NVIDIA GPUs so far), we will do double buffering via rmem instead of smem. The main loop will look like this
+- v3a: double buffering via registers. Since MI300X has limited smem (64KB vs 164KB on Ampere), but plenty of rmem (512KB vs 256KB on all NVIDIA GPUs so far), we will do double buffering via rmem instead of smem. The main loop will look like this
   - Prefetch gmem->rmem for the next tile
   - smem->rmem for the current tile and mfma
   - rmem->smem for the next tile

--- a/02d_matmul_cdna3/README.md
+++ b/02d_matmul_cdna3/README.md
@@ -32,7 +32,7 @@ rocprof-compute analyze -p workloads/mm_v1a/MI300
 ```
 
 Worklog
-- v1a: Basic matmul structure. gmem->smem via registers. No pipelining. Understand mfma layout.  
+- v1a: Basic matmul structure. gmem->smem via registers. No pipelining. Understand mfma layout.
 - Tried `rocprof-compute`, but I didn't know where to look for bottlenecks, like Nsight Compute's warp stall analysis does.
 - v1b: Reduce smem bank conflicts with padded smem or swizzling.
 - Most errors don't segfault / error immediately e.g. reading out of bounds for smem. This makes it hard to identify bugs.


### PR DESCRIPTION
For register files. 
AMD has `4` SIMD,  each with `64` wave size, each thread `512` register and `4B` width. 
sum up to `512 * 64 * 4 * 4 = 512 KB`